### PR TITLE
REP-139 - Change to relative paths in index.html and when building with vite

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,14 +3,14 @@
 
 <head>
   <meta charset="UTF-8" />
-  <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+  <link rel="icon" type="image/svg+xml" href="./vite.svg" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Obcerv Automated Testing Support Matrix</title>
 </head>
 
 <body>
   <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
+  <script type="module" src="./src/main.tsx"></script>
 </body>
 
 </html>

--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build --base ./",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
   },


### PR DESCRIPTION
After merging #1, the page isn't loading the React App because it's loading it from the "/" path, which resolves to https://platorilla.github.io/. This won't work if the website is a subpath (https://platorilla.github.io/obcerv-automated-testing-support-matrix/)

To fix this, I need to train the tools to render relative paths, so that the page can be hosted with or without subpaths.