### PR TITLE
REP-134 -  Fix url link of GitHub repo in the top bar

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Build the project
         env:
-          OATSM_REPO_URL: ${{ github.repositoryUrl }}
+          OATSM_REPO_URL: ${{ github.server_url }}/${{ github.repository }}
           OATSM_COMMIT_VERSION: ${{ github.sha }}
         working-directory: client
         run: npm run build

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -43,7 +43,7 @@ const App = () => {
       <nav className="bg-gray-800 p-4 flex justify-between items-center">
         <h1 className="text-2xl font-bold text-white">Obcerv Automated Testing Support Matrix</h1>
         <div className="text-white">
-          <a href={REPO_URL} target="_blank" rel="noopener noreferrer" className="mr-4">
+          <a href={REPO_URL} target="_blank" rel="noopener noreferrer" className="mr-4 text-sm">
             {`${packageJson.version} (${COMMIT_VERSION})`}
           </a>
         </div>


### PR DESCRIPTION
The link is referring to the `git://` url, which isn't going to work for users. I also made the version text smaller.